### PR TITLE
Handle different signals

### DIFF
--- a/ElevatedBeatsNSlicesPlugin.py
+++ b/ElevatedBeatsNSlicesPlugin.py
@@ -52,7 +52,7 @@ class ElevatedBeatsNSlicesPlugin(Extension):
         self._error_message.show()
         Logger.error(f"An error occurred in QMediaPlayer: {error_dict.get(err_code, str(err_code))}, Error Message: {err_message}")
 
-    def _stopPlaying(self):
+    def _stopPlaying(self, *args, **kwargs):
         Logger.debug("Fading out")
         self._fadeInTimer.stop()  # Stop the fade-in timer
         self._fadeOutTimer = QTimer()


### PR DESCRIPTION
Make sure that different signals can connect with the stop playing method. This fixes a crash when the QMediaPlayer crashes instead of Cura sending the signal to stop playing

Fixes #12

See also Cura Sentry CURA-6MK https://ultimaker-o7.sentry.io/share/issue/f4f8597ca07846c59f397d13e27bf679/